### PR TITLE
Updated "checkpoint" to use "self.use_checkpoint" flag

### DIFF
--- a/guided_diffusion/unet.py
+++ b/guided_diffusion/unet.py
@@ -294,7 +294,7 @@ class AttentionBlock(nn.Module):
         self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
 
     def forward(self, x):
-        return checkpoint(self._forward, (x,), self.parameters(), True)
+        return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
 
     def _forward(self, x):
         b, c, *spatial = x.shape


### PR DESCRIPTION
I want to use the gradient in a loss function, so I do not want to use "checkpoint" since I will use the backward pass twice. This code change simply makes the "use_checkpoint" flag turn off the checkpointing, if requested.